### PR TITLE
make velero bucket name prefix + AWS generated ID, instead of hardcoded

### DIFF
--- a/infrastructure/terraform/kubernetes/velero.tf
+++ b/infrastructure/terraform/kubernetes/velero.tf
@@ -53,7 +53,7 @@ data "aws_iam_policy_document" "velero_policy_document" {
       "s3:ListBucket",
     ]
 
-    resources = ["arn:aws:s3:::${aws_s3_bucket.velero.bucket}", ]
+    resources = [aws_s3_bucket.velero.arn]
   }
 
   statement {
@@ -66,7 +66,7 @@ data "aws_iam_policy_document" "velero_policy_document" {
       "s3:AbortMultipartUpload",
       "s3:ListMultipartUploadParts"
     ]
-    resources = ["arn:aws:s3:::${aws_s3_bucket.velero.bucket}/*", ]
+    resources = ["${aws_s3_bucket.velero.arn}/*", ]
   }
 }
 
@@ -86,5 +86,5 @@ resource "aws_iam_role_policy_attachment" "velero_attach_iam_policy" {
 }
 
 resource "aws_s3_bucket" "velero" {
-  bucket = "velero-opendatahub-bfe86313"
+  bucket_prefix = "velero-opendatahub-"
 }


### PR DESCRIPTION
Hi Christian,

I've tried changing the velero bucket definition to let AWS create it's own prefix-based globally unique name.
Do you have any objections to this?

Cheers,
Clemens
