### PR TITLE
Introduce multi-AZ and HA support

### DIFF
--- a/infrastructure/helm/mongodb/values.yaml
+++ b/infrastructure/helm/mongodb/values.yaml
@@ -8,6 +8,12 @@ fullnameOverride: mongodb
 # Switch to ReplicaSet architecture.
 architecture: replicaset
 
+# Allocate at least one replica for each AZ.
+replicaCount: 3
+
+# Ensure that each pod is scheduled to a different node.
+podAntiAffinityPreset: hard
+
 # ! NOTE: values of `auth.replicaSetKey` and `auth.rootPassword` must be passed
 #         via command-line during `helm install` or `helm upgrade` operations.
 
@@ -22,6 +28,9 @@ auth:
 # We create this manually and don't need it for root.
 # serviceBindings:
 #  enabled: true
+
+persistence:
+  size: 32Gi
 
 resources:
   limits:

--- a/infrastructure/helm/rabbitmq/values.yaml
+++ b/infrastructure/helm/rabbitmq/values.yaml
@@ -5,6 +5,12 @@
 # https://artifacthub.io/packages/helm/bitnami/rabbitmq
 fullnameOverride: rabbitmq
 
+# Allocate at least one replica for each AZ.
+replicaCount: 3
+
+# Ensure that each pod is scheduled to a different node.
+podAntiAffinityPreset: hard
+
 # Set up static authentication.
 auth:
   username: opendatahub
@@ -41,8 +47,6 @@ readinessProbe:
 
 extraConfiguration: |
   consumer_timeout = 60000
-  
-replicaCount: 2
 
 resources:
   limits:

--- a/infrastructure/terraform/compute/eks.tf
+++ b/infrastructure/terraform/compute/eks.tf
@@ -1,6 +1,6 @@
 ################################################################################
 ## This file contains the EKS cluster.
-## https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/19.13.0
+## https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/19.21.0
 ################################################################################
 
 resource  "aws_key_pair" "kubernetes-node" {
@@ -10,7 +10,7 @@ resource  "aws_key_pair" "kubernetes-node" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.13"
+  version = "~> 19.21"
 
   # ----------------------------------------------------------------------------
   # General
@@ -55,13 +55,10 @@ module "eks" {
     main = {
       name = "main-pool"
 
-      # Force single AZ because pods always have to be in same AZ as their persistent volumes
-      subnet_ids = [module.vpc.private_subnets[1]]
-
       # Node group autoscaling.
       max_size     = 5
       desired_size = 3
-      min_size     = 3
+      min_size     = 3 # NOTE: the minimum size must be at least equal to the amount of subnets (zones). 
       key_name = aws_key_pair.kubernetes-node.key_name
 
       # Node instances.


### PR DESCRIPTION
This PR introduces support for multi-AZ cluster distributed across 3 zones and HA support (3 replicas) across all regions for MongoDB and RabbitMQ. This ticket closes https://github.com/noi-techpark/odh-infrastructure-v2/issues/43.